### PR TITLE
add bsp integration icons

### DIFF
--- a/bsp/resources/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_grey.svg
+++ b/bsp/resources/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_grey.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <g fill="none" fill-rule="evenodd">
+    <polygon fill="#9AA7B0" points="12 13.5 10 13.5 10 14.5 12 14.5 12 15.5 14 14.053 12 12.5"/>
+    <polygon fill="#6E6E6E" fill-opacity=".7" points="9.5 15 9.5 13.988 9.5 13 11 13 11 9 9 9 9 16 11 16 11 15"/>
+    <polygon fill="#9AA7B0" points="11 10.947 13 9.5 13 10.5 15 10.5 15 11.5 13 11.5 13 12.5"/>
+    <polygon fill="#6E6E6E" fill-opacity=".7" points="15.5 10 15.5 11.012 15.5 11.5 15.5 12 14 12 14 16 16 16 16 9 14 9 14 10"/>
+    <path fill="#9AA7B0" fill-opacity=".8" d="M8,8 L15,8 L15,4 L7.984,4 L6.696,2.711 C6.305,2.32 5.532,2 4.979,2 L1.051,2 C1.023,2 1,2.022 1,2.051 L1,13 L8,13 L8,8 Z"/>
+  </g>
+</svg>

--- a/bsp/resources/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_red.svg
+++ b/bsp/resources/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_red.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <g fill="none" fill-rule="evenodd">
+    <polygon fill="#9AA7B0" points="12 13.5 10 13.5 10 14.5 12 14.5 12 15.5 14 14.053 12 12.5"/>
+    <polygon fill="#E2325E" fill-opacity=".7" points="9.5 15 9.5 13.988 9.5 13 11 13 11 9 9 9 9 16 11 16 11 15"/>
+    <polygon fill="#9AA7B0" points="11 10.947 13 9.5 13 10.5 15 10.5 15 11.5 13 11.5 13 12.5"/>
+    <polygon fill="#E2325E" fill-opacity=".7" points="15.5 10 15.5 11.012 15.5 11.5 15.5 12 14 12 14 16 16 16 16 9 14 9 14 10"/>
+    <path fill="#9AA7B0" fill-opacity=".8" d="M8,8 L15,8 L15,4 L7.984,4 L6.696,2.711 C6.305,2.32 5.532,2 4.979,2 L1.051,2 C1.023,2 1,2.022 1,2.051 L1,13 L8,13 L8,8 Z"/>
+  </g>
+</svg>

--- a/scala/integration/bsp/resources/META-INF/scala-bsp-integration.xml
+++ b/scala/integration/bsp/resources/META-INF/scala-bsp-integration.xml
@@ -3,5 +3,6 @@
         <bspProjectOpenProcessorExtension
                 implementation="org.jetbrains.plugins.scala.bsp.flow.open.ScalaBspProjectOpenProcessor"/>
         <bspProjectAwareExtension implementation="org.jetbrains.plugins.scala.bsp.config.ScalaBspProjectAwareExtension"/>
+        <buildToolAssetsExtension implementation="org.jetbrains.plugins.scala.bsp.assets.ScalaAssetsExtension" />
     </extensions>
 </idea-plugin>

--- a/scala/integration/bsp/src/org/jetbrains/plugins/scala/bsp/assets/ScalaAssetsExtension.scala
+++ b/scala/integration/bsp/src/org/jetbrains/plugins/scala/bsp/assets/ScalaAssetsExtension.scala
@@ -1,0 +1,22 @@
+package org.jetbrains.plugins.scala.bsp.assets
+
+import com.intellij.openapi.util.IconLoader
+import org.jetbrains.plugins.bsp.assets.BuildToolAssetsExtension
+import org.jetbrains.plugins.bsp.flow.open.BuildToolId
+import org.jetbrains.plugins.scala.bsp.config.ScalaPluginConstants
+
+import javax.swing.Icon
+
+class ScalaAssetsExtension extends BuildToolAssetsExtension {
+  override def getIcon: Icon = IconLoader.getIcon("/org/jetbrains/plugins/scala/bsp/images/buildServerProtocol.svg", classOf[ScalaAssetsExtension])
+
+  override def getLoadedTargetIcon: Icon = IconLoader.getIcon("/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget.svg", classOf[ScalaAssetsExtension])
+
+  override def getInvalidTargetIcon: Icon = IconLoader.getIcon("/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_red.svg", classOf[ScalaAssetsExtension])
+
+  override def getUnloadedTargetIcon: Icon = IconLoader.getIcon("/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_grey.svg", classOf[ScalaAssetsExtension])
+
+  override def getPresentableName: String = ScalaPluginConstants.SYSTEM_ID.getReadableName
+
+  override def getBuildToolId: BuildToolId = new BuildToolId(ScalaPluginConstants.SYSTEM_ID.getId)
+}

--- a/scala/integration/bsp/src/org/jetbrains/plugins/scala/bsp/assets/ScalaAssetsExtension.scala
+++ b/scala/integration/bsp/src/org/jetbrains/plugins/scala/bsp/assets/ScalaAssetsExtension.scala
@@ -16,7 +16,7 @@ class ScalaAssetsExtension extends BuildToolAssetsExtension {
 
   override def getUnloadedTargetIcon: Icon = IconLoader.getIcon("/org/jetbrains/plugins/scala/bsp/images/buildServerProtocolTarget_grey.svg", classOf[ScalaAssetsExtension])
 
-  override def getPresentableName: String = ScalaPluginConstants.SYSTEM_ID.getReadableName
+  override def getPresentableName: String = "sbt"
 
-  override def getBuildToolId: BuildToolId = new BuildToolId(ScalaPluginConstants.SYSTEM_ID.getId)
+  override def getBuildToolId: BuildToolId = new BuildToolId("sbt")
 }


### PR DESCRIPTION
[Bazel implementation](https://github.com/JetBrains/intellij-bazel/blob/989f93226725cb33e7520eb55a2a0b2b09ffcc98/src/main/kotlin/org/jetbrains/bazel/assets/BazelAssetsExtension.kt#L7) for reference
I needed to make additional icons, so I based them on the existing ones, and I used the shade of red from intellij-bazel